### PR TITLE
Slight code re-organization

### DIFF
--- a/lib/unobtrusive_flash/controller_mixin.rb
+++ b/lib/unobtrusive_flash/controller_mixin.rb
@@ -4,11 +4,15 @@ module UnobtrusiveFlash
   module ControllerMixin
     protected
 
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
     def prepare_unobtrusive_flash
       return unless flash.any?
       # TODO: replace configuration based on overriding methods with a conventional config block
       cookies[:flash] = {
-        value: UnobtrusiveFlash::ControllerMixin.append_flash_to_cookie(cookies[:flash], flash, unobtrusive_flash_keys),
+        value: append_flash_to_cookie(cookies[:flash], flash, unobtrusive_flash_keys),
         domain: unobtrusive_flash_domain
       }
       flash.discard
@@ -37,7 +41,9 @@ module UnobtrusiveFlash
       [:notice, :alert, :error, :success, :warning]
     end
 
-    class << self
+    module ClassMethods
+      extend self
+
       # Prepares a safe and clean version of the flash hash for the frontend
       # flash - value of `flash` controller attribute
       # displayable_flash_keys - list of flash keys that will be displayed

--- a/lib/unobtrusive_flash/controller_mixin.rb
+++ b/lib/unobtrusive_flash/controller_mixin.rb
@@ -12,7 +12,7 @@ module UnobtrusiveFlash
       return unless flash.any?
       # TODO: replace configuration based on overriding methods with a conventional config block
       cookies[:flash] = {
-        value: append_flash_to_cookie(cookies[:flash], flash, unobtrusive_flash_keys),
+        value: self.class.append_flash_to_cookie(cookies[:flash], flash, unobtrusive_flash_keys),
         domain: unobtrusive_flash_domain
       }
       flash.discard

--- a/spec/sanitize_flash_spec.rb
+++ b/spec/sanitize_flash_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe UnobtrusiveFlash::ControllerMixin do
+describe UnobtrusiveFlash::ControllerMixin::ClassMethods, type: :controller do
   describe '.sanitize_flash' do
     it 'should escape messages that are not html safe' do
       expect(described_class.sanitize_flash({:notice => '<bar>'}, [:notice])).to eq([["notice", '&lt;bar&gt;']])


### PR DESCRIPTION
The current organization of this gem makes it difficult to customize the behavior of this gem because it contains explicit references to fully qualified method: `UnobtrusiveFlash::ControllerMixin.append_flash_to_cookie` (which we had a need to tweak slightly).

I reorganized to make this unneeded and also to follow a common module pattern in the ruby community. This change was beneficial to my team and I suspect might be appreciated by others. It allowed us to easily override methods as needed and the code remains easily testable.