### PR TITLE
Better handle `cacheable-flash` transitioners

### DIFF
--- a/lib/unobtrusive_flash/controller_mixin.rb
+++ b/lib/unobtrusive_flash/controller_mixin.rb
@@ -50,15 +50,16 @@ module UnobtrusiveFlash
       end
 
       def append_flash_to_cookie(existing_cookie, flash, unobtrusive_flash_keys)
-        cookie_flash = (existing_cookie && parse_cookie(existing_cookie)) || []
-        cookie_flash += sanitize_flash(flash, unobtrusive_flash_keys)
+        cookie_flash = (existing_cookie && parse_cookie(existing_cookie))
+        cookie_flash = [] unless cookie_flash.is_a? Array
+        cookie_flash += self.sanitize_flash(flash, unobtrusive_flash_keys)
         cookie_flash.uniq.to_json
       end
 
       def parse_cookie(existing_cookie)
         JSON.parse(existing_cookie)
       rescue JSON::JSONError
-        nil
+        []
       end
     end
   end

--- a/lib/unobtrusive_flash/controller_mixin.rb
+++ b/lib/unobtrusive_flash/controller_mixin.rb
@@ -52,7 +52,7 @@ module UnobtrusiveFlash
       def append_flash_to_cookie(existing_cookie, flash, unobtrusive_flash_keys)
         cookie_flash = (existing_cookie && parse_cookie(existing_cookie))
         cookie_flash = [] unless cookie_flash.is_a? Array
-        cookie_flash += self.sanitize_flash(flash, unobtrusive_flash_keys)
+        cookie_flash += sanitize_flash(flash, unobtrusive_flash_keys)
         cookie_flash.uniq.to_json
       end
 

--- a/spec/sanitize_flash_spec.rb
+++ b/spec/sanitize_flash_spec.rb
@@ -20,6 +20,14 @@ describe UnobtrusiveFlash::ControllerMixin do
       expect(described_class.append_flash_to_cookie(nil, {:baz => 'qux'}, [:baz])).to eq('[["baz","qux"]]')
     end
 
+    it 'should gracefully handle non-conforming cookies' do
+      expect(described_class.append_flash_to_cookie('{}', {:baz => 'qux'}, [:baz])).to eq('[["baz","qux"]]')
+    end
+
+    it 'should gracefully handle tampered cookies' do
+      expect(described_class.append_flash_to_cookie('some_invalid_json', {:baz => 'qux'}, [:baz])).to eq('[["baz","qux"]]')
+    end
+
     it 'should reuse existing cookie' do
       expect(described_class.append_flash_to_cookie('[["foo","bar"]]', {:baz => 'qux'}, [:baz])).to eq('[["foo","bar"],["baz","qux"]]')
     end


### PR DESCRIPTION
The `cacheable-flash` gem is no longer maintained and the author suggests `unobtrusive_flash` as its successor: https://github.com/pboling/cacheable-flash

However, the flash cookie format is different between these two libraries. This patch will make the transition from one to the other more painless (and as an added side effect also to help to handle tampered cookies that may not be in the expected format). I manually did this locally for our project and figured others might benefit from it as well.